### PR TITLE
Added setOnTintColor: Override

### DIFF
--- a/Source/AMViralSwitch.m
+++ b/Source/AMViralSwitch.m
@@ -62,6 +62,11 @@ NSString *const AMElementToValue = @"AMElementToValue";
     [self switchChanged:self];
 }
 
+- (void)setOnTintColor:(UIColor *)onColor {
+    [super setOnTintColor:onColor];
+    self.shape.fillColor = onColor.CGColor;
+}
+
 - (void)switchChanged:(UISwitch *)sender {
     if (sender.on) {
         [CATransaction begin];


### PR DESCRIPTION
Fixes the situation where theTintColor can't be changed programmatically once the switch already been drawn to the screen.